### PR TITLE
fix '@param' command used in a comment that is not attached to a func…

### DIFF
--- a/jsmn.h
+++ b/jsmn.h
@@ -33,9 +33,9 @@ enum jsmnerr {
 
 /**
  * JSON token description.
- * @param		type	type (object, array, string etc.)
- * @param		start	start position in JSON data string
- * @param		end		end position in JSON data string
+ * 	type	type (object, array, string etc.)
+ * 	start	start position in JSON data string
+ * 	end		end position in JSON data string
  */
 typedef struct {
 	jsmntype_t type;


### PR DESCRIPTION
…tion declaration [-Wdocumentation]

When build with clang and use -Wdocumentation CFLAG
